### PR TITLE
Update redis.yml

### DIFF
--- a/archives/deployarr_v4/compose/redis.yml
+++ b/archives/deployarr_v4/compose/redis.yml
@@ -8,7 +8,7 @@ services:
     restart: unless-stopped
     profiles: ["core", "all"]
     healthcheck:
-      test: ["CMD-SHELL", "redis-cli ping | grep PONG"]
+      test: ["CMD-SHELL", "redis-cli -a $REDIS_PASSWORD ping | grep PONG"]
       start_period: 20s
       interval: 30s
       retries: 5


### PR DESCRIPTION
The health check command needs to be authenticated using the set password. Otherwise it will fail and the container will always be reported as unhealthy